### PR TITLE
Switch docker-compose.yml to use pgsql

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,18 +1,17 @@
-mysql:
-  image: mysql:5.6
+postgres:
+  image: postgres:9.4.4
   environment:
-    - MYSQL_ROOT_PASSWORD=cachet
-    - MYSQL_DATABASE=cachet
-    - MYSQL_USER=cachet
-    - MYSQL_PASSWORD=cachet
+    - POSTGRES_USER=postgres
+    - POSTGRES_PASSWORD=postgres
 cachet:
   build: .
   ports:
     - 80:8000
   links:
-    - mysql:mysql
+    - postgres:postgres
   environment:
-    - DB_HOST=mysql
-    - DB_DATABASE=cachet
-    - DB_USERNAME=cachet
-    - DB_PASSWORD=cachet
+    - DB_DRIVER=pgsql
+    - DB_HOST=postgres
+    - DB_DATABASE=postgres
+    - DB_USERNAME=postgres
+    - DB_PASSWORD=postgres


### PR DESCRIPTION
Change to `docker-compose.yml` to utilize postgresql instead of MySQL. Does not require immediately updating docs, since MySQL will still work fine also.

Closes #2 