### PR TITLE
move entrypoint COPY step down below the cachet setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,15 @@
 FROM cachethq/docker:base-d3506c1
 
-COPY docker/entrypoint.sh /sbin/entrypoint.sh
 RUN cd /var/www/html && \
     wget https://github.com/cachethq/Cachet/archive/v1.2.0.tar.gz && \
     tar xzvf v1.2.0.tar.gz --strip-components=1 && \
     chown -R www-data /var/www/html && \
     rm -r v1.2.0.tar.gz && \
     php composer.phar install --no-dev -o && \
-    cp -n vendor/jenssegers/date/src/Lang/zh.php vendor/jenssegers/date/src/Lang/zh-CN.php 
+    cp -n vendor/jenssegers/date/src/Lang/zh.php vendor/jenssegers/date/src/Lang/zh-CN.php
+
+COPY docker/entrypoint.sh /sbin/entrypoint.sh
+
 WORKDIR /var/www/html/
 
 # copy the various nginx and supervisor conf (to handle both fpm and nginx)


### PR DESCRIPTION
Should help the image layer cache when working on `entrypoint.sh` and then rebuilding the container for testing.

This way the cache will not get invalidated on changes to `entrypoint.sh` - helping us skip the lengthy downloads and composer install portion