### PR TITLE
Use upstream cachet master

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM cachethq/docker:base-d3506c1
+FROM cachethq/docker:base
 
 RUN cd /var/www/html && \
-    wget https://github.com/cachethq/Cachet/archive/v1.2.1.tar.gz && \
-    tar xzvf v1.2.1.tar.gz --strip-components=1 && \
+    wget https://github.com/cachethq/Cachet/archive/master.tar.gz && \
+    tar xzvf master.tar.gz --strip-components=1 && \
     chown -R www-data /var/www/html && \
-    rm -r v1.2.1.tar.gz && \
+    rm -r master.tar.gz && \
     php composer.phar install --no-dev -o && \
     cp -n vendor/jenssegers/date/src/Lang/zh.php vendor/jenssegers/date/src/Lang/zh-CN.php
 


### PR DESCRIPTION
Uses latest base image as well as latest upstream Cachet master - this is built on docker hub as `cachethq\cachet:latest`

Based on feedback in: https://github.com/cachethq/Cachet/issues/1186