### PR TITLE
Revert to Jessie + init fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,24 @@
-FROM debian:sid
+FROM debian:jessie
 
 MAINTAINER Alt Three <support@alt-three.com>
 
-# Using debian jessie packages instead of compiling from scratch
+# Using debian packages instead of compiling from scratch
 RUN DEBIAN_FRONTEND=noninteractive \
     echo "APT::Install-Recommends \"0\";" >> /etc/apt/apt.conf.d/02recommends && \
     echo "APT::Install-Suggests \"0\";" >> /etc/apt/apt.conf.d/02recommends && \
     apt-get clean && \
     apt-get -q -y update && \
     apt-get -q -y install \
-    ca-certificates php7.0-cli php7.0-fpm php7.0-gd php7.0-mbstring php7.0-mysql php7.0-pgsql php7.0-sqlite \
-    wget sqlite git libsqlite3-dev curl supervisor cron unzip && \
+    ca-certificates php5-fpm=5.* php5-curl php5-readline php5-mcrypt \
+    php5-mysql php5-apcu php5-cli php5-gd php5-mysql php5-pgsql php5-sqlite \
+    wget sqlite git libsqlite3-dev postgresql-client mysql-client curl supervisor cron unzip && \
     apt-get clean && apt-get autoremove -q && \
     rm -rf /var/lib/apt/lists/* /usr/share/doc /usr/share/man /tmp/*
 
 COPY docker/supervisord.conf /etc/supervisor/supervisord.conf
-COPY docker/php-fpm-pool.conf /etc/php/7.0/fpm/pool.d/www.conf
+COPY docker/php-fpm-pool.conf /etc/php5/fpm/pool.d/www.conf
 
-RUN sed -i -e "s/;daemonize\s*=\s*yes/daemonize = no/g" /etc/php/7.0/fpm/php-fpm.conf && \
-    mkdir /run/php
+RUN sed -i -e "s/;daemonize\s*=\s*yes/daemonize = no/g" /etc/php5/fpm/php-fpm.conf
 
 WORKDIR /var/www/html/
 
@@ -42,4 +42,5 @@ RUN chmod 0644 /etc/cron.d/artisan-schedule &&\
 VOLUME /var/www
 EXPOSE 8000
 
-CMD ["/sbin/entrypoint.sh"]
+ENTRYPOINT ["/sbin/entrypoint.sh"]
+CMD ["start"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,65 +1,127 @@
 #!/bin/bash
 set -e
 
-APP_ENV=${APP_ENV:-production}
-APP_DEBUG=${APP_DEBUG:-false}
-APP_URL=${APP_URL:-http://localhost}
-APP_KEY=${APP_KEY:-SECRET}
+[[ $DEBUG == true ]] && set -x
 
-DB_DRIVER=${DB_DRIVER:-mysql}
-DB_HOST=${DB_HOST:-mysql}
-DB_DATABASE=${DB_DATABASE:-cachet}
-DB_USERNAME=${DB_USERNAME:-cachet}
-DB_PASSWORD=${DB_PASSWORD:-cachet}
+check_database_connection() {
+  case ${DB_DRIVER} in
+    mysql)
+      prog="mysqladmin -h ${DB_HOST} -u ${DB_USERNAME} ${DB_PASSWORD:+-p$DB_PASSWORD} status"
+      ;;
+    pgsql)
+      prog=$(find /usr/lib/postgresql/ -name pg_isready)
+      prog="${prog} -h ${DB_HOST} -U ${DB_USERNAME} -d ${DB_DATABASE} -t 1"
+      ;;
+  esac
+  timeout=60
+  while ! ${prog} >/dev/null 2>&1
+  do
+    timeout=$(expr $timeout - 1)
+    if [[ $timeout -eq 0 ]]; then
+      echo
+      echo "Could not connect to database server. Aborting..."
+      return 1
+    fi
+    echo -n "."
+    sleep 1
+  done
+  echo
+}
 
-CACHE_DRIVER=${CACHE_DRIVER:-file}
-SESSION_DRIVER=${SESSION_DRIVER:-file}
-QUEUE_DRIVER=${QUEUE_DRIVER:-database}
+initialize_system() {
+  APP_ENV=${APP_ENV:-development}
+  APP_DEBUG=${APP_DEBUG:-true}
+  APP_URL=${APP_URL:-http://localhost}
+  APP_KEY=${APP_KEY:-SECRET}
 
-MAIL_DRIVER=${MAIL_DRIVER:-smtp}
-MAIL_HOST=${MAIL_HOST:-mailtrap.io}
-MAIL_PORT=${MAIL_PORT:-2525}
-MAIL_USERNAME=${MAIL_USERNAME:-null}
-MAIL_PASSWORD=${MAIL_PASSWORD:-null}
-MAIL_ADDRESS=${MAIL_ADDRESS:-null}
-MAIL_NAME=${MAIL_NAME:-null}
+  DB_DRIVER=${DB_DRIVER:-mysql}
+  DB_HOST=${DB_HOST:-mysql}
+  DB_DATABASE=${DB_DATABASE:-cachet}
+  DB_USERNAME=${DB_USERNAME:-cachet}
+  DB_PASSWORD=${DB_PASSWORD:-cachet}
 
-REDIS_HOST=${REDIS_HOST:-null}
-REDIS_DATABASE=${REDIS_DATABASE:-null}
-REDIS_PORT=${REDIS_PORT:-null}
+  CACHE_DRIVER=${CACHE_DRIVER:-apc}
+  SESSION_DRIVER=${SESSION_DRIVER:-apc}
+  QUEUE_DRIVER=${QUEUE_DRIVER:-apc}
 
-# configure env file
+  MAIL_DRIVER=${MAIL_DRIVER:-smtp}
+  MAIL_HOST=${MAIL_HOST:-mailtrap.io}
+  MAIL_PORT=${MAIL_PORT:-2525}
+  MAIL_USERNAME=${MAIL_USERNAME:-null}
+  MAIL_PASSWORD=${MAIL_PASSWORD:-null}
+  MAIL_ADDRESS=${MAIL_ADDRESS:-null}
+  MAIL_NAME=${MAIL_NAME:-null}
 
-sed 's,{{APP_ENV}},'"${APP_ENV}"',g' -i /var/www/html/.env
-sed 's,{{APP_DEBUG}},'"${APP_DEBUG}"',g' -i /var/www/html/.env
-sed 's,{{APP_URL}},'"${APP_URL}"',g' -i /var/www/html/.env
-sed 's,{{APP_KEY}},'"${APP_KEY}"',g' -i /var/www/html/.env
+  REDIS_HOST=${REDIS_HOST:-null}
+  REDIS_DATABASE=${REDIS_DATABASE:-null}
+  REDIS_PORT=${REDIS_PORT:-null}
 
-sed 's,{{DB_DRIVER}},'"${DB_DRIVER}"',g' -i /var/www/html/.env
-sed 's,{{DB_HOST}},'"${DB_HOST}"',g' -i /var/www/html/.env
-sed 's,{{DB_DATABASE}},'"${DB_DATABASE}"',g' -i /var/www/html/.env
-sed 's,{{DB_USERNAME}},'"${DB_USERNAME}"',g' -i /var/www/html/.env
-sed 's,{{DB_PASSWORD}},'"${DB_PASSWORD}"',g' -i /var/www/html/.env
+  # configure env file
 
-sed 's,{{CACHE_DRIVER}},'"${CACHE_DRIVER}"',g' -i /var/www/html/.env
-sed 's,{{SESSION_DRIVER}},'"${SESSION_DRIVER}"',g' -i /var/www/html/.env
-sed 's,{{QUEUE_DRIVER}},'"${QUEUE_DRIVER}"',g' -i /var/www/html/.env
+  sed 's,{{APP_ENV}},'"${APP_ENV}"',g' -i /var/www/html/.env
+  sed 's,{{APP_DEBUG}},'"${APP_DEBUG}"',g' -i /var/www/html/.env
+  sed 's,{{APP_URL}},'"${APP_URL}"',g' -i /var/www/html/.env
+  sed 's,{{APP_KEY}},'"${APP_KEY}"',g' -i /var/www/html/.env
 
-sed 's,{{MAIL_DRIVER}},'"${MAIL_DRIVER}"',g' -i /var/www/html/.env
-sed 's,{{MAIL_HOST}},'"${MAIL_HOST}"',g' -i /var/www/html/.env
-sed 's,{{MAIL_PORT}},'"${MAIL_PORT}"',g' -i /var/www/html/.env
-sed 's,{{MAIL_USERNAME}},'"${MAIL_USERNAME}"',g' -i /var/www/html/.env
-sed 's,{{MAIL_PASSWORD}},'"${MAIL_PASSWORD}"',g' -i /var/www/html/.env
-sed 's,{{MAIL_ADDRESS}},'"${MAIL_ADDRESS}"',g' -i /var/www/html/.env
-sed 's,{{MAIL_NAME}},'"${MAIL_NAME}"',g' -i /var/www/html/.env
+  sed 's,{{DB_DRIVER}},'"${DB_DRIVER}"',g' -i /var/www/html/.env
+  sed 's,{{DB_HOST}},'"${DB_HOST}"',g' -i /var/www/html/.env
+  sed 's,{{DB_DATABASE}},'"${DB_DATABASE}"',g' -i /var/www/html/.env
+  sed 's,{{DB_USERNAME}},'"${DB_USERNAME}"',g' -i /var/www/html/.env
+  sed 's,{{DB_PASSWORD}},'"${DB_PASSWORD}"',g' -i /var/www/html/.env
 
-sed 's,{{REDIS_HOST}},'"${REDIS_HOST}"',g' -i /var/www/html/.env
-sed 's,{{REDIS_DATABASE}},'"${REDIS_DATABASE}"',g' -i /var/www/html/.env
-sed 's,{{REDIS_PORT}},'"${REDIS_PORT}"',g' -i /var/www/html/.env
+  sed 's,{{CACHE_DRIVER}},'"${CACHE_DRIVER}"',g' -i /var/www/html/.env
+  sed 's,{{SESSION_DRIVER}},'"${SESSION_DRIVER}"',g' -i /var/www/html/.env
+  sed 's,{{QUEUE_DRIVER}},'"${QUEUE_DRIVER}"',g' -i /var/www/html/.env
 
-php composer.phar install --no-dev -o
+  sed 's,{{MAIL_DRIVER}},'"${MAIL_DRIVER}"',g' -i /var/www/html/.env
+  sed 's,{{MAIL_HOST}},'"${MAIL_HOST}"',g' -i /var/www/html/.env
+  sed 's,{{MAIL_PORT}},'"${MAIL_PORT}"',g' -i /var/www/html/.env
+  sed 's,{{MAIL_USERNAME}},'"${MAIL_USERNAME}"',g' -i /var/www/html/.env
+  sed 's,{{MAIL_PASSWORD}},'"${MAIL_PASSWORD}"',g' -i /var/www/html/.env
+  sed 's,{{MAIL_ADDRESS}},'"${MAIL_ADDRESS}"',g' -i /var/www/html/.env
+  sed 's,{{MAIL_NAME}},'"${MAIL_NAME}"',g' -i /var/www/html/.env
 
-echo "Starting supervisord..."
-exec /usr/bin/supervisord -n -c /etc/supervisor/supervisord.conf
+  sed 's,{{REDIS_HOST}},'"${REDIS_HOST}"',g' -i /var/www/html/.env
+  sed 's,{{REDIS_DATABASE}},'"${REDIS_DATABASE}"',g' -i /var/www/html/.env
+  sed 's,{{REDIS_PORT}},'"${REDIS_PORT}"',g' -i /var/www/html/.env
+
+  php composer.phar install --no-dev -o
+  php artisan key:generate
+  php artisan app:install
+  rm -rf bootstrap/cache/*
+  touch /.cachet-installed
+  start_system
+}
+
+start_system() {
+  check_database_connection
+  [ -f "/.cachet-installed" ] && echo "Starting Cachet" || initialize_system
+  php artisan config:cache
+  exec /usr/bin/supervisord -n -c /etc/supervisor/supervisord.conf
+}
+
+case ${1} in
+  init|start)
+
+    case ${1} in
+      start)
+        start_system
+        ;;
+      init)
+        initialize_system
+        ;;
+    esac
+    ;;
+  help)
+    echo "Available options:"
+    echo " start        - Starts the Cachet server (default)"
+    echo " init         - Initialize the Cachet server (e.g. create databases, compile assets)."
+    echo " help         - Displays the help"
+    echo " [command]        - Execute the specified command, eg. bash."
+    ;;
+  *)
+    exec "$@"
+    ;;
+esac
 
 exit 0

--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -19,7 +19,7 @@ supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
 serverurl=unix:///var/run/supervisor.sock ; use a unix:// URL  for a unix socket
 
 [program:php-fpm7.0]
-command=/usr/sbin/php-fpm7.0 -c /etc/php/7.0/fpm
+command=/usr/sbin/php5-fpm -c /etc/php5/fpm
 
 [program:cron]
 command=/usr/sbin/cron -f


### PR DESCRIPTION
Addresses a few outstanding issues.

* Fixes #57 - Reverted to a Debian Jessie base, using official php and APCu packages

* Closes #36 - On first run, key is generated, database is initialized and `/.cachet-installed` touch file is added, so that we don't run the `php artisan key:generate` and `php artisan app:install` on the second run. Caveat to this is if the Cachet container is deleted (such as on an upgrade) we lose the touchfile. Per the warning in the Cachet install guide: __Never change the APP_KEY after installation on production environment. This will result in all of your encrypted/hashed data being lost.__ -- May need to clarify what that data is that is lost. Another option (probably the right option) is to query for an appropriate value in the database.

* _May_ also address #34 - I am able to restart the container consistently.

* Adds a check for DB reachability to prevent race conditions.