### PR TITLE
2.3 Image enhancements 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,14 +18,13 @@ The below example shows creating a `v2.2.1` release.
 ```
 git checkout master
 git checkout -b rel-2.2.1
-sed -i s/master/v2.2.1/g Dockerfile
+Set `ENV cachetversion=v2.2.1` in Dockerfile
 git commit -am "Cachet v2.2.1 release"
 git tag -a v2.2.1 -m "Cachet Release v2.2.1"
 git push origin v2.2.1
 ```
 
-Then to finish the process: 
+Then to finish the process:
 
 * Add [Release on GitHub](https://github.com/CachetHQ/Docker/releases)
 * Add automated build for the new tag on [Docker Hub](https://hub.docker.com/r/cachethq/docker/builds/)
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:jessie
 
 MAINTAINER Alt Three <support@alt-three.com>
-ENV cachetversion=v2.3.0-RC2
+ENV cachetversion=master
 
 # Using debian packages instead of compiling from scratch
 RUN DEBIAN_FRONTEND=noninteractive \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 FROM debian:jessie
 
 MAINTAINER Alt Three <support@alt-three.com>
-ENV cachetversion=master
+
+ARG cachet_ver
+ENV cachet_ver master
 
 # Using debian packages instead of compiling from scratch
 RUN DEBIAN_FRONTEND=noninteractive \
@@ -38,10 +40,10 @@ USER www-data
 # Install composer
 RUN curl -sS https://getcomposer.org/installer | php
 
-RUN wget https://github.com/cachethq/Cachet/archive/${cachetversion}.tar.gz && \
-    tar xzvf ${cachetversion}.tar.gz --strip-components=1 && \
+RUN wget https://github.com/cachethq/Cachet/archive/${cachet_ver}.tar.gz && \
+    tar xzvf ${cachet_ver}.tar.gz --strip-components=1 && \
     chown -R www-data /var/www/html && \
-    rm -r ${cachetversion}.tar.gz && \
+    rm -r ${cachet_ver}.tar.gz && \
     php composer.phar install --no-dev -o
 
 COPY docker/.env.docker /var/www/html/.env

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -89,15 +89,15 @@ initialize_system() {
   php composer.phar install --no-dev -o
   php artisan app:install
   rm -rf bootstrap/cache/*
-  touch /.cachet-installed
+  touch /var/www/.cachet-installed
   start_system
 }
 
 start_system() {
   check_database_connection
-  [ -f "/.cachet-installed" ] && echo "Starting Cachet" || initialize_system
+  [ -f "/var/www/.cachet-installed" ] && echo "Starting Cachet" || initialize_system
   php artisan config:cache
-  exec /usr/bin/supervisord -n -c /etc/supervisor/supervisord.conf
+  sudo /usr/bin/supervisord -n -c /etc/supervisor/supervisord.conf
 }
 
 case ${1} in

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -34,11 +34,12 @@ initialize_system() {
   APP_URL=${APP_URL:-http://localhost}
   APP_KEY=${APP_KEY:-SECRET}
 
-  DB_DRIVER=${DB_DRIVER:-mysql}
-  DB_HOST=${DB_HOST:-mysql}
+  DB_DRIVER=${DB_DRIVER:-pgsql}
+  DB_HOST=${DB_HOST:-postgres}
   DB_DATABASE=${DB_DATABASE:-cachet}
-  DB_USERNAME=${DB_USERNAME:-cachet}
-  DB_PASSWORD=${DB_PASSWORD:-cachet}
+  DB_USERNAME=${DB_USERNAME:-postgres}
+  DB_PASSWORD=${DB_PASSWORD:-postgres}
+  DB_PORT=${DB_PORT:-5432}
 
   CACHE_DRIVER=${CACHE_DRIVER:-apc}
   SESSION_DRIVER=${SESSION_DRIVER:-apc}

--- a/docker/php-fpm-pool.conf
+++ b/docker/php-fpm-pool.conf
@@ -6,11 +6,10 @@ listen = 9000
 
 request_terminate_timeout = 120s
 
-pm = dynamic
+pm = ondemand
 pm.max_children = 5
-pm.start_servers = 2
-pm.min_spare_servers = 1
-pm.max_spare_servers = 3
+pm.process_idle_timeout = 10s
+pm.max_requests = 500
 chdir = /
 
 env[DB_DRIVER] = $DB_DRIVER

--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -1,6 +1,3 @@
-[unix_http_server]
-file=/var/run/supervisor.sock   ; (the path to the socket file)
-
 [supervisord]
 logfile=/dev/null             ; (main log file;default $CWD/supervisord.log)
 logfile_maxbytes=0            ; (max main logfile bytes b4 rotation;default 50MB)


### PR DESCRIPTION
- [x] Run more things as www-data user
- [x] Use `ENV` in Dockerfile to specify Cachet version (simplify new release process)
- [x] Run php-fpm workers on-demand rather than preforking
- [x] disable supervisor http socket (not used)
- [x] Take advantage of [ARG](https://docs.docker.com/engine/reference/builder/#arg) in Dockerfile to allow specifying `cachet_ver` during manual builds

Merging these fixes back into master, then will cut a 2.3.0 tag and release when it is released upstream.