### PR TITLE
fix. cachet_ver couldn't be overrided with ARG

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:jessie
 MAINTAINER Alt Three <support@alt-three.com>
 
 ARG cachet_ver
-ENV cachet_ver master
+ENV cachet_ver ${cachet_ver:-master}
 
 ENV PG_MAJOR 9.5
 ENV NGINX_VERSION 1.10.1-1~jessie
@@ -12,7 +12,7 @@ ENV COMPOSER_VERSION 1.2.1
 RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8
 RUN apt-key adv --keyserver hkp://pgp.mit.edu:80 --recv-keys 573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62
 
-RUN echo "deb http://nginx.org/packages/debian/ jessie nginx" >> /etc/apt/sources.list 
+RUN echo "deb http://nginx.org/packages/debian/ jessie nginx" >> /etc/apt/sources.list
 RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ jessie-pgdg main' $PG_MAJOR > /etc/apt/sources.list.d/pgdg.list
 
 # Using debian packages instead of compiling from scratch


### PR DESCRIPTION
I tried to build with a specific sha1 and it was not possible to wget something else than master archive.