### PR TITLE
Bump docker version in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,20 +5,13 @@ services:
 
 env:
     global:
-        - DOCKER_VERSION=1.12.1-0~trusty
         - DOCKER_COMPOSE_VERSION=1.7.1
 
 before_install:
-    # list docker-engine versions
-    - apt-cache madison docker-engine
-
     # add bats repo https://github.com/tkuchiki/bats-travis-ci
     - sudo add-apt-repository ppa:duggan/bats --yes
     - sudo apt-get update -qq
     - sudo apt-get install -qq bats
-
-    # upgrade docker-engine to specific version
-    - sudo apt-get -o Dpkg::Options::="--force-confnew" install -y docker-engine=${DOCKER_VERSION}
 
     # reinstall docker-compose at specific version
     - sudo rm /usr/local/bin/docker-compose

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ services:
 
 env:
     global:
-        - DOCKER_VERSION=1.10.1-0~trusty
+        - DOCKER_VERSION=1.12.1-0~trusty
         - DOCKER_COMPOSE_VERSION=1.7.1
 
 before_install:


### PR DESCRIPTION
Use the default docker version that travisci provides (future-proofing the tests)