### PR TITLE
Add cachet_ver ARG to docker-compose.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,11 @@ Cachet is a BSD-3-licensed open source project. If you'd like to support future 
 
 2. Edit the docker-compose.yml file to specify your [ENV variables](/conf/.env.docker).
 
-3. To build image containing a specific Cachet release, set the [`cachet_ver` ARG in the docker-compose.yml](/docker-compose.yml)
+3. To build an image containing a specific Cachet release, set the [`cachet_ver` ARG in the docker-compose.yml](/docker-compose.yml)
+
+  The *master* branch and *cachethq/docker:latest* Docker automated build are a work in progress / development version of the upstream https://github.com/CachetHQ/Cachet project. As such, *master* or *latest* should not be used in a production environment as it can change at anytime.
+
+  We strongly recommend specifying a stable [Cachet Release](https://github.com/CachetHQ/Cachet/releases) at build time as mentioned above.
 
 4. Build and run the image
 
@@ -36,8 +40,6 @@ Cachet is a BSD-3-licensed open source project. If you'd like to support future 
 `cachethq/docker` is available as a [Docker Hub Trusted Build](https://hub.docker.com/r/cachethq/docker/).
 
 For a full list of Cachet versions released as Docker images  please see the [list of Docker hub tags](https://hub.docker.com/r/cachethq/docker/tags/).
-
-The master branch and `cachethq/docker:latest` Docker automated build are a work in progress / development version of the upstream [Cachet](https://github.com/CachetHQ/Cachet) project. Use of `master` or `:latest` in a production environment is not recommended as it may change at any time.
 
 Please use a [tagged Cachet Docker image release](https://github.com/CachetHQ/Docker/releases) or one of the tagged builds from https://hub.docker.com/r/cachethq/docker/tags/ with `docker pull cachethq/docker:2.3.10`.
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,27 @@ For full documentation, visit the [Installing Cachet with Docker](https://docs.c
 
 Cachet is a BSD-3-licensed open source project. If you'd like to support future development, check out the [Cachet Patreon](https://patreon.com/jbrooksuk) campaign.
 
+# Quickstart
+
+1. Clone this repository
+
+  ```shell
+  git clone https://github.com/CachetHQ/Cachet.git
+  ```
+
+2. Edit the docker-compose.yml file to specify your [ENV variables](/conf/.env.docker).
+
+3. To build image containing a specific Cachet release, set the [`cachet_ver` ARG in the docker-compose.yml](/docker-compose.yml)
+
+4. Build and run the image
+
+  ```shell
+  docker-compose build
+  docker-compose up
+  ```
+
+5. `cachethq/docker` runs on port 80 by default
+
 # Docker Hub Automated build
 
 `cachethq/docker` is available as a [Docker Hub Trusted Build](https://hub.docker.com/r/cachethq/docker/).
@@ -18,7 +39,7 @@ For a full list of Cachet versions released as Docker images  please see the [li
 
 The master branch and `cachethq/docker:latest` Docker automated build are a work in progress / development version of the upstream [Cachet](https://github.com/CachetHQ/Cachet) project. Use of `master` or `:latest` in a production environment is not recommended as it may change at any time.
 
-Please use a [tagged Cachet Docker image release](https://github.com/CachetHQ/Docker/releases) or one of the tagged builds from https://hub.docker.com/r/cachethq/docker/tags/ with `docker pull cachethq/docker:2.2.1`.
+Please use a [tagged Cachet Docker image release](https://github.com/CachetHQ/Docker/releases) or one of the tagged builds from https://hub.docker.com/r/cachethq/docker/tags/ with `docker pull cachethq/docker:2.3.10`.
 
 # Testing
 
@@ -30,7 +51,7 @@ Use `make test` to manually run the tests.
 # Development of Cachet using this docker environment
 
 1.  Clone the official repo of CachetHQ/Docker
-  
+
   ```shell
   git clone https://github.com/cachethq/Docker.git cachet-docker
   cd cachet-docker
@@ -38,13 +59,13 @@ Use `make test` to manually run the tests.
   git checkout $LATEST_TAG
   ```
 2. Clone the official repo of CachetHQ/Cachet here and do composer install
-  
+
   ```shell
   git clone https://github.com/CachetHQ/Cachet.git
   ```
 
 3. Setup the Cachet project
- 
+
  ```shell
  cd Cachet
 composer install
@@ -55,25 +76,25 @@ cd ..
 4. Edit the docker-compose.yml file
 
   ```yaml
-  replace 
-    build: . 
-  with 
+  replace
+    build: .
+  with
     image: cachethq/docker
 
   replace
-    - /var/www 
-  with 
+    - /var/www
+  with
     - ./Cachet/:/var/www/html/
   ```
 
 5. Build and run the docker compose
-  
+
   ```shell
   docker-compose up
   ```
-  
-6. Open new terminal and execute the following commands after getting container name via `docker ps`:
-  
+
+6. Open new terminal and run the following commands after getting container name via `docker ps`:
+
   ```shell
   docker exec -i cachetdocker_cachet_1  php artisan key:generate
   docker exec -i cachetdocker_cachet_1  php artisan app:install

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     build:
       context: .
       args:
-        - cachet_ver=v2.3.10
+        - cachet_ver=master
     ports:
       - 80:8000
     links:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,10 @@ services:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres
   cachet:
-    build: .
+    build:
+      context: .
+      args:
+        - cachet_ver=v2.3.10
     ports:
       - 80:8000
     links:


### PR DESCRIPTION
Allows easily overriding the `cachet_ver` argument so that a specific Cachet release can be overridden. This should make it easier to take advantage of the fixes in the Docker image master branch, while still running a "stable" version of Cachet.

Also adds a quickstart guide to the README, which will also be added to the https://docs.cachethq.io/docs/get-started-with-docker guide