### PR TITLE
Switch to Alpine Linux

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -45,5 +45,7 @@ http {
     client_body_temp_path /tmp 1 2;
     client_body_buffer_size 256k;
     client_body_in_file_only off;
+
+    proxy_temp_path /tmp/proxy 1 2;
 }
 daemon off;

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -41,5 +41,9 @@ http {
     gzip_types text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript application/vnd.ms-fontobject application/x-font-ttf font/opentype image/svg+xml image/x-icon;
 
     include /etc/nginx/conf.d/*.conf;
+
+    client_body_temp_path /tmp 1 2;
+    client_body_buffer_size 256k;
+    client_body_in_file_only off;
 }
 daemon off;

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -47,6 +47,6 @@ http {
     client_body_in_file_only off;
 
     proxy_temp_path /tmp/proxy 1 2;
-    fastgci_temp_path /tmp/fastcgi 1 2;
+    fastcgi_temp_path /tmp/fastcgi 1 2;
 }
 daemon off;

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -47,5 +47,6 @@ http {
     client_body_in_file_only off;
 
     proxy_temp_path /tmp/proxy 1 2;
+    fastgci_temp_path /tmp/fastcgi 1 2;
 }
 daemon off;

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -48,5 +48,6 @@ http {
 
     proxy_temp_path /tmp/proxy 1 2;
     fastcgi_temp_path /tmp/fastcgi 1 2;
+    uwsgi_temp_path /tmp/fastcgi 1 2;
 }
 daemon off;

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -49,5 +49,6 @@ http {
     proxy_temp_path /tmp/proxy 1 2;
     fastcgi_temp_path /tmp/fastcgi 1 2;
     uwsgi_temp_path /tmp/fastcgi 1 2;
+    scgi_temp_path /tmp/scgi 1 2;
 }
 daemon off;

--- a/conf/php-fpm-pool.conf
+++ b/conf/php-fpm-pool.conf
@@ -22,4 +22,4 @@ access.log = /dev/stdout
 [global]
 daemonize = no
 error_log = /dev/stderr
-pid = /var/run/php-fpm.pid
+pid = /tmp/php-fpm.pid

--- a/conf/php-fpm-pool.conf
+++ b/conf/php-fpm-pool.conf
@@ -22,4 +22,4 @@ access.log = /dev/stdout
 [global]
 daemonize = no
 error_log = /dev/stderr
-pid = /var/run/php5-fpm.pid
+pid = /var/run/php-fpm.pid

--- a/conf/supervisord.conf
+++ b/conf/supervisord.conf
@@ -25,7 +25,8 @@ stdout_logfile=/dev/stdout
 stderr_logfile=/dev/stderr
 
 [program:php-fpm]
-command=/usr/sbin/php5-fpm -c /etc/php5/fpm
+command=/usr/sbin/php-fpm7 -c /etc/php7/fpm/pool.d/www.conf
+catch_workers_output = Yes
 stdout_events_enabled=true
 stderr_events_enabled=true
 stdout_logfile_maxbytes=0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       - DB_PASSWORD=postgres
       - DB_PREFIX=chq_
       - APP_KEY=${APP_KEY:-null}
-      - DEBUG=true
+      - DEBUG=false
     depends_on:
       - postgres
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       - DB_PASSWORD=postgres
       - DB_PREFIX=chq_
       - APP_KEY=${APP_KEY:-null}
-      - DEBUG=false
+      - DEBUG=true
     depends_on:
       - postgres
     restart: always

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,7 +10,7 @@ check_database_connection() {
       prog="mysqladmin -h ${DB_HOST} -u ${DB_USERNAME} ${DB_PASSWORD:+-p$DB_PASSWORD} status"
       ;;
     pgsql)
-      prog=$(find /usr/lib/postgresql/ -name pg_isready)
+      prog="/usr/bin/pg_isready"
       prog="${prog} -h ${DB_HOST} -U ${DB_USERNAME} -d ${DB_DATABASE} -t 1"
       ;;
   esac
@@ -169,7 +169,7 @@ initialize_system() {
   sed 's,{{NEXMO_SECRET}},'${NEXMO_SECRET}',g' -i /var/www/html/.env
   sed 's,{{NEXMO_SMS_FROM}},'${NEXMO_SMS_FROM}',g' -i /var/www/html/.env
 
-  sudo sed 's,{{PHP_MAX_CHILDREN}},'"${PHP_MAX_CHILDREN}"',g' -i /etc/php5/fpm/pool.d/www.conf
+  sudo sed 's,{{PHP_MAX_CHILDREN}},'"${PHP_MAX_CHILDREN}"',g' -i /etc/php7/php-fpm.d/www.conf
 
   rm -rf bootstrap/cache/*
   chmod -R 777 storage


### PR DESCRIPTION
Switching to [Alpine Linux](https://alpinelinux.org/) as a base image.

- [x] PHP 7 support #168 
- [x] Image size reduced by about half (debian = ~450MB, alpine = ~250MB)
- [x] Fix fpm pid name / location
- [x] Using newer NGINX base image

This is a pretty big change, moving from debian to alpine. The smaller image size, and ability to go to PHP 7 quickly are the biggest benefits.