### PR TITLE
Remove docker version pin in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,17 +2,11 @@ sudo: required
 
 env:
     global:
-        - DOCKER_VERSION=1.13.1-0~ubuntu-trusty
         - DOCKER_COMPOSE_VERSION=1.11.2
 services:
         - docker
 
 before_install:
-    # list docker-engine versions
-    - apt-cache madison docker-engine
-
-    # upgrade docker-engine to specific version
-    - sudo apt-get -o Dpkg::Options::="--force-confnew" install -y docker-engine=${DOCKER_VERSION}
 
     # install docker-compose at specific version
     - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose


### PR DESCRIPTION
May be easier to maintain the CI if we dont pin a version, and just use default.

Looking to address the build failure in #214 