### PR TITLE
All vars used in `sed` commands wrapped in double quotes;

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -152,22 +152,22 @@ initialize_system() {
   sed 's,{{MAIL_DRIVER}},'"${MAIL_DRIVER}"',g' -i /var/www/html/.env
   sed 's,{{MAIL_HOST}},'"${MAIL_HOST}"',g' -i /var/www/html/.env
   sed 's,{{MAIL_PORT}},'"${MAIL_PORT}"',g' -i /var/www/html/.env
-  sed 's,{{MAIL_USERNAME}},'${MAIL_USERNAME}',g' -i /var/www/html/.env
-  sed 's,{{MAIL_PASSWORD}},'${MAIL_PASSWORD}',g' -i /var/www/html/.env
-  sed 's,{{MAIL_ADDRESS}},'${MAIL_ADDRESS}',g' -i /var/www/html/.env
-  sed 's,{{MAIL_NAME}},'${MAIL_NAME}',g' -i /var/www/html/.env
-  sed 's,{{MAIL_ENCRYPTION}},'${MAIL_ENCRYPTION}',g' -i /var/www/html/.env
+  sed 's,{{MAIL_USERNAME}},'"${MAIL_USERNAME}"',g' -i /var/www/html/.env
+  sed 's,{{MAIL_PASSWORD}},'"${MAIL_PASSWORD}"',g' -i /var/www/html/.env
+  sed 's,{{MAIL_ADDRESS}},'"${MAIL_ADDRESS}"',g' -i /var/www/html/.env
+  sed 's,{{MAIL_NAME}},'"${MAIL_NAME}"',g' -i /var/www/html/.env
+  sed 's,{{MAIL_ENCRYPTION}},'"${MAIL_ENCRYPTION}"',g' -i /var/www/html/.env
 
-  sed 's,{{REDIS_HOST}},'${REDIS_HOST}',g' -i /var/www/html/.env
-  sed 's,{{REDIS_DATABASE}},'${REDIS_DATABASE}',g' -i /var/www/html/.env
-  sed 's,{{REDIS_PORT}},'${REDIS_PORT}',g' -i /var/www/html/.env
-  sed 's,{{REDIS_PASSWORD}},'${REDIS_PASSWORD}',g' -i /var/www/html/.env
+  sed 's,{{REDIS_HOST}},'"${REDIS_HOST}"',g' -i /var/www/html/.env
+  sed 's,{{REDIS_DATABASE}},'"${REDIS_DATABASE}"',g' -i /var/www/html/.env
+  sed 's,{{REDIS_PORT}},'"${REDIS_PORT}"',g' -i /var/www/html/.env
+  sed 's,{{REDIS_PASSWORD}},'"${REDIS_PASSWORD}"',g' -i /var/www/html/.env
 
   sed 's,{{GITHUB_TOKEN}},'"${GITHUB_TOKEN}"',g' -i /var/www/html/.env
 
-  sed 's,{{NEXMO_KEY}},'${NEXMO_KEY}',g' -i /var/www/html/.env
-  sed 's,{{NEXMO_SECRET}},'${NEXMO_SECRET}',g' -i /var/www/html/.env
-  sed 's,{{NEXMO_SMS_FROM}},'${NEXMO_SMS_FROM}',g' -i /var/www/html/.env
+  sed 's,{{NEXMO_KEY}},'"${NEXMO_KEY}"',g' -i /var/www/html/.env
+  sed 's,{{NEXMO_SECRET}},'"${NEXMO_SECRET}"',g' -i /var/www/html/.env
+  sed 's,{{NEXMO_SMS_FROM}},'"${NEXMO_SMS_FROM}"',g' -i /var/www/html/.env
 
   sudo sed 's,{{PHP_MAX_CHILDREN}},'"${PHP_MAX_CHILDREN}"',g' -i /etc/php7/php-fpm.d/www.conf
 


### PR DESCRIPTION
Prevents errors when certain characters, such as spaces, are used for vars such as MAIL_NAME.

To reproduce the bug, specify a name that includes a space for MAIL_NAME. You'll get an error from `sed` when running `docker-compose up`.  This resolves this error.

This was reported in #201, but the issue was closed when the user gave up and decided to simply not use spaces in the MAIL_NAME var.