### PR TITLE
Force Linux line endings on entrypoint.sh

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Force Linux line endings to fix issues on Windows
+/entrypoint.sh text eol=lf


### PR DESCRIPTION
This fixes issues when using Docker on Windows.

Without this, the entrypoint.sh script is checked out with Windows line endings and the cachet container fails to start.

(This issue only occurs when Git's `core.autocrlf` setting is enabled on Windows, but adding this file ensures that entrypoint.sh is checked out with the correct line endings regardless of that setting.)