### PR TITLE
Updated supervisord.conf

### DIFF
--- a/conf/supervisord.conf
+++ b/conf/supervisord.conf
@@ -40,4 +40,6 @@ directory=/var/www/html/
 redirect_stderr=true
 autostart=true
 autorestart=true
+stdout_logfile_maxbytes=0
+stderr_logfile_maxbytes=0
 stdout_logfile=/dev/stdout


### PR DESCRIPTION
Added:
stdout_logfile_maxbytes=0
stderr_logfile_maxbytes=0

to the queue-worker in order to prevent:
cachet_1    | [2017-08-03 21:03:02] Failed: mailer@handleQueuedMessage
cachet_1    | 2017-08-03 21:03:02,072 CRIT uncaptured python exception, closing channel <POutputDispatcher at 140405233150720 for <Subprocess at 140405233597184 with name queue-worker in state RUNNING> (stdout)> (<type 'exceptions.IOError'>:[Errno 29] Invalid seek [/usr/lib/python2.7/site-packages/supervisor/supervisord.py|runforever|235] [/usr/lib/python2.7/site-packages/supervisor/dispatchers.py|handle_read_event|232] [/usr/lib/python2.7/site-packages/supervisor/dispatchers.py|record_output|166] [/usr/lib/python2.7/site-packages/supervisor/dispatchers.py|_log|142] [/usr/lib/python2.7/site-packages/supervisor/loggers.py|info|275] [/usr/lib/python2.7/site-packages/supervisor/loggers.py|log|293] [/usr/lib/python2.7/site-packages/supervisor/loggers.py|emit|186] [/usr/lib/python2.7/site-packages/supervisor/loggers.py|doRollover|211])

when using an invalid mail provider configuration running in a docker container.