### PR TITLE
Resolve missing simplexml support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,7 @@ RUN apk add --no-cache --update \
     php7-phar \
     php7-posix \
     php7-session \
+    php7-simplexml \
     php7-soap \
     php7-xml \
     php7-zip \


### PR DESCRIPTION
> cachet_1    | 2018/03/16 23:13:12 [error] 64#64: *48 FastCGI sent in stderr: "PHP message: [2018-03-16 23:13:12] development.CRITICAL: Symfony\Component\Debug\Exception\FatalThrowableError: Call to undefined function CachetHQ\Cachet\Integrations\Core\simplexml_load_string() in /var/www/html/app/Integrations/Core/Feed.php:77

Followed the docker getting started guide, but when accessing the dashboard for the first time I came across the above error, resolved by adding in `php7-simplexml`.