### PR TITLE
Replaced Master version with 2.4

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     build:
       context: .
       args:
-        - cachet_ver=master
+        - cachet_ver=2.4
     ports:
       - 80:8000
     links:


### PR DESCRIPTION
During the docker-compose build we pass on cachet_ver=master from the docker-compose.yml

So the Dockerfile is using:
ARG cachet_ver
ENV cachet_ver ${cachet_ver:-master}

resulting in the build process downloading:
RUN wget https://github.com/cachethq/Cachet/archive/master.tar.gz

but that branch had it's *Latest commit a2a36cd  on 29 Dec 2016* ......... + *This branch is 9 commits ahead, 2407 commits behind 2.4.*

Which will not make anyone happy (no wonder the docker is lacking "_a little_" behind ^^ )

I'd suggest this to be updated in case you want to deliver a pleasant experience for Docker users or keep the master branch updated from now on.

For now I would  change the Default in the docker-compose.yml from:
cachet_ver=master to cachet_ver=2.4 in order to prevent Docker users from having more issues than necessary.