### PR TITLE
Remove caching logic from nginx-site.conf

### DIFF
--- a/conf/nginx-site.conf
+++ b/conf/nginx-site.conf
@@ -17,37 +17,15 @@ server {
       expires 365d;
     }
 
-    #Cache everything by default
-    set $no_cache 0;
-
-    # Only cache GET requests
-    if ($request_method != GET){
-        set $no_cache 1;
-    }
-
-    #Don't cache if the URL contains a query string
-    if ($query_string != ""){
-        set $no_cache 1;
-    }
-
-    #Don't cache the following URLs
-    if ($request_uri ~* "/(login|dashboard|admin|components/)"){
-        set $no_cache 1;
-    }
-
     # Pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
     location ~ \.php$ {
-        fastcgi_cache  microcache;
-        fastcgi_cache_key $scheme$host$request_uri$request_method;
-        fastcgi_cache_valid 200 301 302 30s;
-        fastcgi_cache_use_stale updating error timeout invalid_header http_500;
 
         fastcgi_pass_header Set-Cookie;
         fastcgi_pass_header Cookie;
         fastcgi_ignore_headers Cache-Control Expires Set-Cookie;
 
-        fastcgi_cache_bypass $no_cache;
-        fastcgi_no_cache $no_cache;
+        fastcgi_cache_bypass 1;
+        fastcgi_no_cache 1;
 
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
         include fastcgi_params;


### PR DESCRIPTION
Fixes #272

This basically rips out all of the caching logic from the nginx config, as a rough cut to make this docker container safe to deploy on public sites. I think we could go back to caching some pages, but I think some of this lies upstream with cachet/Cachet to address, to enable a front page that is safe to cache aggressively (as a status page should be).

Can I request that this get merged and a container pushed quickly, and this advertised as a urgent update for those using this docker container, as full access to the dashboard for non-logged in users is quite a severe problem.

I've tested this locally and it seems to have the right behaviour - I've not managed to share between systems yet, but absence of proof is not proof of absence.