### PR TITLE
removed the --no-dev flag as it prevents the use of latest 2.4 Cachet

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ RUN apk add --no-cache --update \
     php7-iconv \
     php7-intl \
     php7-json \
+    sqlite \
     php7-mbstring \
     php7-mcrypt \
     php7-mysqlnd \
@@ -42,9 +43,11 @@ RUN apk add --no-cache --update \
     php7-phar \
     php7-posix \
     php7-session \
+    php7-sqlite3 \
     php7-simplexml \
     php7-soap \
     php7-xml \
+    php7-xmlwriter \
     php7-zip \
     php7-zlib \
     php7-tokenizer \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ CMD ["/sbin/entrypoint.sh"]
 ARG cachet_ver
 ARG archive_url
 
-ENV cachet_ver ${cachet_ver:-2.4}
+ENV cachet_ver ${cachet_ver:-master}
 ENV archive_url ${archive_url:-https://github.com/cachethq/Cachet/archive/${cachet_ver}.tar.gz}
 
 ENV COMPOSER_VERSION 1.6.3
@@ -83,7 +83,7 @@ RUN wget ${archive_url} && \
     chown -R www-data:root /var/www/html && \
     rm -r ${cachet_ver}.tar.gz && \
     php /bin/composer.phar global require "hirak/prestissimo:^0.3" && \
-    php /bin/composer.phar install -o && \
+    php /bin/composer.phar install --no-dev -o && \
     rm -rf bootstrap/cache/*
 
 COPY conf/php-fpm-pool.conf /etc/php7/php-fpm.d/www.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ CMD ["/sbin/entrypoint.sh"]
 ARG cachet_ver
 ARG archive_url
 
-ENV cachet_ver ${cachet_ver:-master}
+ENV cachet_ver ${cachet_ver:-2.4}
 ENV archive_url ${archive_url:-https://github.com/cachethq/Cachet/archive/${cachet_ver}.tar.gz}
 
 ENV COMPOSER_VERSION 1.6.3
@@ -83,7 +83,7 @@ RUN wget ${archive_url} && \
     chown -R www-data:root /var/www/html && \
     rm -r ${cachet_ver}.tar.gz && \
     php /bin/composer.phar global require "hirak/prestissimo:^0.3" && \
-    php /bin/composer.phar install --no-dev -o && \
+    php /bin/composer.phar install -o && \
     rm -rf bootstrap/cache/*
 
 COPY conf/php-fpm-pool.conf /etc/php7/php-fpm.d/www.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -83,7 +83,7 @@ RUN wget ${archive_url} && \
     chown -R www-data:root /var/www/html && \
     rm -r ${cachet_ver}.tar.gz && \
     php /bin/composer.phar global require "hirak/prestissimo:^0.3" && \
-    php /bin/composer.phar install --no-dev -o && \
+    php /bin/composer.phar install -o && \
     rm -rf bootstrap/cache/*
 
 COPY conf/php-fpm-pool.conf /etc/php7/php-fpm.d/www.conf


### PR DESCRIPTION
As using as default 2.4 branch is currently refused, there's still a need to remove the --no-dev flag, to be able to switch to it from command line.