### PR TITLE
Deprecate MAINTAINER

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 FROM nginx:1.13.9-alpine
 
-MAINTAINER Alt Three <support@alt-three.com>
-
 EXPOSE 8000
 CMD ["/sbin/entrypoint.sh"]
 


### PR DESCRIPTION
MAINTAINER is deprecated in Dockerfiles since Docker 1.13.0