### PR TITLE
Hotfix: adjusting empty APP_KEY validation

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -187,7 +187,7 @@ initialize_system() {
   
   sed 's,{{TRUSTED_PROXIES}},'"${TRUSTED_PROXIES}"',g' -i /var/www/html/.env
   
-  if [[ -z "${APP_KEY}" ]]; then
+  if [[ -z "${APP_KEY}" || "${APP_KEY}" = "null" ]]; then
     keygen="$(php artisan key:generate)"
     APP_KEY=$(echo "${keygen}" | grep -oP '(?<=\[).*(?=\])')
     echo "ERROR: Please set the 'APP_KEY=${APP_KEY}' environment variable at runtime or in docker-compose.yml and re-launch"


### PR DESCRIPTION
## Description
This is a fix to APP_KEY settlement on docker entrypoint

## Related Issue
https://github.com/CachetHQ/Docker/issues/322
https://github.com/CachetHQ/Docker/issues/310

## Motivation and Context
This pull request solves the empty app key problem. It's a simple logic error when the default value settled on docker-compose is null for APP_KEY and in runtime null isn't means null, but a string value. 

## How Has This Been Tested?
1) run docker compose up --build command
1.1) you have a valid base64 key settled on docker-compose APP_KEY value, so will works fine
1.2) you have the default value settled (null), so in docker-compose up command will hang and inform that you need to set the informed key (desired behavior)
1.3) you have a non-expected value settled, so in docker-compose up command will hang and outputs the php error stacktrace (expected behavior)
