### PR TITLE
RFC: use upstream PHP base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,100 +1,102 @@
-FROM nginx:1.17.8-alpine
+FROM php:7.1-fpm-alpine
 
-EXPOSE 8000
-CMD ["/sbin/entrypoint.sh"]
+LABEL maintainer="Alt Three <support@alt-three.com>"
 
-ARG cachet_ver
-ARG archive_url
+# entrypoint.sh dependencies
+RUN apk add --no-cache \
+	bash \
+	nginx \
+	postgresql-client \
+	supervisor
 
-ENV cachet_ver ${cachet_ver:-2.4}
-ENV archive_url ${archive_url:-https://github.com/cachethq/Cachet/archive/${cachet_ver}.tar.gz}
+# Install PHP extensions
+RUN set -eux; \
+	\
+	apk add --no-cache --virtual .build-deps \
+		$PHPIZE_DEPS \
+		libjpeg-turbo-dev \
+		libmcrypt-dev \
+		libmemcached-dev \
+		libpng-dev \
+		openldap-dev \
+		pcre-dev \
+		postgresql-dev \
+		sqlite-dev \
+	; \
+	\
+	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr; \
+	docker-php-ext-install \
+		gd \
+		mysqli \
+		opcache \
+		pdo_mysql \
+		pdo_pgsql \
+		pdo_sqlite \
+		pgsql \
+		zip \
+	; \
+	\
+# pecl will claim success even if one install fails, so we need to perform each install separately
+	pecl install APCu-5.1.17; \
+	pecl install redis-4.3.0; \
+	\
+	docker-php-ext-enable \
+		apcu \
+		redis \
+	; \
+	\
+	runDeps="$( \
+		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local/lib/php/extensions \
+			| tr ',' '\n' \
+			| sort -u \
+			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
+	)"; \
+	apk add --virtual .postfixadmin-phpexts-rundeps $runDeps; \
+	apk del .build-deps
 
+# set recommended PHP.ini settings
+# see https://secure.php.net/manual/en/opcache.installation.php
+RUN { \
+		echo 'opcache.memory_consumption=128'; \
+		echo 'opcache.interned_strings_buffer=8'; \
+		echo 'opcache.max_accelerated_files=4000'; \
+		echo 'opcache.revalidate_freq=2'; \
+		echo 'opcache.fast_shutdown=1'; \
+	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
+
+#VOLUME /var/www/html
 ENV COMPOSER_VERSION 1.9.0
 
-RUN apk add --no-cache --update \
-    postgresql-client \
-    postgresql \
-    mysql-client \
-    php7 \
-    php7-redis \
-    php7-apcu \
-    php7-bcmath \
-    php7-dom \
-    php7-ctype \
-    php7-curl \
-    php7-fpm \
-    php7-fileinfo \
-    php7-gd \
-    php7-iconv \
-    php7-intl \
-    php7-json \
-    sqlite \
-    php7-mbstring \
-    php7-mcrypt \
-    php7-mysqlnd \
-    php7-opcache \
-    php7-openssl \
-    php7-pdo \
-    php7-pdo_mysql \
-    php7-pdo_pgsql \
-    php7-pdo_sqlite \
-    php7-phar \
-    php7-posix \
-    php7-session \
-    php7-sqlite3 \
-    php7-simplexml \
-    php7-soap \
-    php7-xml \
-    php7-xmlwriter \
-    php7-zip \
-    php7-zlib \
-    php7-tokenizer \
-    wget sqlite git curl bash grep \
-    supervisor
-
-# forward request and error logs to docker log collector
-RUN ln -sf /dev/stdout /var/log/nginx/access.log && \
-    ln -sf /dev/stderr /var/log/nginx/error.log && \
-    ln -sf /dev/stdout /var/log/php7/error.log && \
-    ln -sf /dev/stderr /var/log/php7/error.log
-
-RUN adduser -S -s /bin/bash -u 1001 -G root www-data
-
-RUN touch /var/run/nginx.pid && \
-    chown -R www-data:root /var/run/nginx.pid /etc/php7/php-fpm.d
-
-RUN mkdir -p /var/www/html && \
-    mkdir -p /usr/share/nginx/cache && \
-    mkdir -p /var/cache/nginx && \
-    mkdir -p /var/lib/nginx && \
-    chown -R www-data:root /var/www /usr/share/nginx/cache /var/cache/nginx /var/lib/nginx/
-
 # Install composer
-RUN wget https://getcomposer.org/installer -O /tmp/composer-setup.php && \
-    wget https://composer.github.io/installer.sig -O /tmp/composer-setup.sig && \
-    php -r "if (hash('SHA384', file_get_contents('/tmp/composer-setup.php')) !== trim(file_get_contents('/tmp/composer-setup.sig'))) { unlink('/tmp/composer-setup.php'); echo 'Invalid installer' . PHP_EOL; exit(1); }" && \
-    php /tmp/composer-setup.php --version=$COMPOSER_VERSION --install-dir=bin && \
-    php -r "unlink('/tmp/composer-setup.php');"
+RUN set -eux; \
+	curl -fsSL https://getcomposer.org/installer -o /tmp/composer-setup.php; \
+	curl -fsSL https://composer.github.io/installer.sig -o /tmp/composer-setup.sig; \
+	php -r "if (hash('SHA384', file_get_contents('/tmp/composer-setup.php')) !== trim(file_get_contents('/tmp/composer-setup.sig'))) { unlink('/tmp/composer-setup.php'); echo 'Invalid installer' . PHP_EOL; exit(1); }"; \
+	php /tmp/composer-setup.php --version=$COMPOSER_VERSION --install-dir=/bin; \
+	php -r "unlink('/tmp/composer-setup.php');"
 
-WORKDIR /var/www/html/
-USER 1001
+ARG cachet_ver=2.3.18
+ARG archive_url=https://github.com/CachetHQ/Cachet/archive/v${cachet_ver}.tar.gz
 
-RUN wget ${archive_url} && \
-    tar xzf ${cachet_ver}.tar.gz --strip-components=1 && \
-    chown -R www-data:root /var/www/html && \
-    rm -r ${cachet_ver}.tar.gz && \
-    php /bin/composer.phar global require "hirak/prestissimo:^0.3" && \
-    php /bin/composer.phar install -o && \
-    rm -rf bootstrap/cache/*
+ENV cachet_ver ${cachet_ver}
+ENV archive_url ${archive_url}
+
+RUN set -eux; \
+	curl -o cachet.tar.gz -fSL "${archive_url}"; \
+	# upstream tarball include ./Cachet-${cachet_ver}/
+	tar -xf cachet.tar.gz -C /var/www/html --strip-components=1; \
+	rm cachet.tar.gz; \
+	composer.phar global require "hirak/prestissimo:^0.3"; \
+	composer.phar install -q -o; \
+	rm -rf bootstrap/cache/* ~/.composer /bin/composer.phar; \
+	chown -R www-data:www-data /var/www/html
 
 COPY conf/php-fpm-pool.conf /etc/php7/php-fpm.d/www.conf
 COPY conf/supervisord.conf /etc/supervisor/supervisord.conf
 COPY conf/nginx.conf /etc/nginx/nginx.conf
 COPY conf/nginx-site.conf /etc/nginx/conf.d/default.conf
 COPY conf/.env.docker /var/www/html/.env
-COPY entrypoint.sh /sbin/entrypoint.sh
+COPY entrypoint.sh /usr/local/bin/
 
-USER root
-RUN chmod g+rwx /var/run/nginx.pid && \
-    chmod -R g+rw /var/www /usr/share/nginx/cache /var/cache/nginx /var/lib/nginx/ /etc/php7/php-fpm.d storage
-USER 1001
+EXPOSE 8000
+CMD ["entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ LABEL maintainer="Alt Three <support@alt-three.com>"
 RUN apk add --no-cache \
 	bash \
 	nginx \
+	mysql-client \
 	postgresql-client \
 	supervisor
 

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -26,7 +26,7 @@ http {
 
     keepalive_timeout  65;
 
-    fastcgi_cache_path /usr/share/nginx/cache/fcgi levels=1:2 keys_zone=microcache:10m max_size=1024m inactive=1h;
+    fastcgi_cache_path /var/lib/nginx/tmp levels=1:2 keys_zone=microcache:10m max_size=1024m inactive=1h;
     add_header X-Cache $upstream_cache_status;
 
     gzip on;

--- a/conf/supervisord.conf
+++ b/conf/supervisord.conf
@@ -25,7 +25,7 @@ stdout_logfile=/dev/stdout
 stderr_logfile=/dev/stderr
 
 [program:php-fpm]
-command=/usr/sbin/php-fpm7 -c /etc/php7/fpm/pool.d/www.conf
+command=/usr/local/sbin/php-fpm -c /etc/php7/fpm/pool.d/www.conf
 catch_workers_output = Yes
 stdout_events_enabled=true
 stderr_events_enabled=true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     build:
       context: .
       args:
-        - cachet_ver=2.4
+        - cachet_ver=2.3.18
     ports:
       - 80:8000
     links:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -o errexit -o nounset -o pipefail
+set -euo pipefail
 
 [ "${DEBUG:-false}" == true ] && set -x
 
@@ -204,7 +204,7 @@ initialize_system() {
 
 init_db() {
   echo "Initializing Cachet database ..."
-  php artisan cachet:install --no-interaction
+  php artisan app:install --no-interaction
   check_configured
 }
 


### PR DESCRIPTION
I propose to use the PHP image of the docker library: https://hub.docker.com/_/php

As a first step, this PR keeps the current concept with nginx and supervisor running the same container. I'd also like to introduce some [best practices for writing Dockerfiles](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/).
My goal is to get rid of supervisor completely and providing a pure FPM variant and a variant using php-apache as an alternative. This concept is inspired by other well known PHP images like [Wordpress](https://hub.docker.com/_/wordpress), [Drupal](https://hub.docker.com/_/drupal), [Joomla](https://hub.docker.com/_/joomla), [Nextcloud](https://hub.docker.com/_/nextcloud), [Matomo](https://hub.docker.com/_/matomo) etc. They all run and scale pretty well in production.

You can find more information about the docker library and how to become an "official image" yourself here:
* https://github.com/docker-library/official-images#contributing-to-the-standard-library
* https://github.com/docker-library/faq#frequently-asked-questions

Please let me know how you think about it and if I should continue with this. Feel free to reach out if you have any questions.