### PR TITLE
Fix for 'FPM initialisation failed'.

### DIFF
--- a/conf/php-fpm-pool.conf
+++ b/conf/php-fpm-pool.conf
@@ -1,5 +1,7 @@
 [www]
 listen = 127.0.0.1:9000
+user = www-data
+group = www-data
 
 request_terminate_timeout = 120s
 

--- a/test1
+++ b/test1
@@ -1,0 +1,1 @@
+Commit trigger check.

--- a/test1
+++ b/test1
@@ -1,1 +1,2 @@
 Commit trigger check.
+And again.

--- a/test1
+++ b/test1
@@ -1,2 +1,3 @@
 Commit trigger check.
 And again.
+And some more.


### PR DESCRIPTION
I found this was needed to avoid the following errors when running the latest docker image `cachethq/Docker`.

```
2020-05-11 11:10:51,534 INFO spawned: 'php-fpm' with pid 88
[11-May-2020 11:10:51] ERROR: [pool www] please specify user and group other than root
[11-May-2020 11:10:51] ERROR: [pool www] please specify user and group other than root
[11-May-2020 11:10:51] ERROR: FPM initialization failed
[11-May-2020 11:10:51] ERROR: FPM initialization failed
2020-05-11 11:10:51,576 INFO exited: php-fpm (exit status 78; not expected)
```