### PR TITLE
start postfix at runtime if sendmail is used

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,7 @@ RUN apk add --no-cache --update \
     postgresql \
     postgresql-client \
     sqlite \
+    sudo \
     wget sqlite git curl bash grep \
     supervisor
 
@@ -61,8 +62,12 @@ RUN ln -sf /dev/stdout /var/log/nginx/access.log && \
 
 RUN adduser -S -s /bin/bash -u 1001 -G root www-data
 
+RUN echo "www-data	ALL=(ALL:ALL)	NOPASSWD:SETENV:	/usr/sbin/postfix" >> /etc/sudoers
+
 RUN touch /var/run/nginx.pid && \
-    chown -R www-data:root /var/run/nginx.pid /etc/php7/php-fpm.d
+    chown -R www-data:root /var/run/nginx.pid
+
+RUN chown -R www-data:root /etc/php7/php-fpm.d
 
 RUN mkdir -p /var/www/html && \
     mkdir -p /usr/share/nginx/cache && \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -67,6 +67,12 @@ check_configured() {
   esac
 }
 
+check_sendmail() {
+	if [[ "${MAIL_DRIVER:-}" == "sendmail" ]]; then
+		sudo /usr/sbin/postfix start
+	fi
+}
+
 initialize_system() {
   echo "Initializing Cachet container ..."
 
@@ -231,6 +237,7 @@ start_system() {
   /usr/bin/supervisord -n -c /etc/supervisor/supervisord.conf
 }
 
+check_sendmail
 start_system
 
 exit 0


### PR DESCRIPTION
@djdefi this is the correct fix for sendmail

it checks if `sendmail` is selected. If so then postfix is used. otherwise everything stays the same

fixes #232 