### PR TITLE
Fix #379 - cachet::install should be app::install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.17.8-alpine
+FROM nginx:1.14.0-alpine
 
 EXPOSE 8000
 CMD ["/sbin/entrypoint.sh"]
@@ -6,7 +6,7 @@ CMD ["/sbin/entrypoint.sh"]
 ARG cachet_ver
 ARG archive_url
 
-ENV cachet_ver ${cachet_ver:-2.4}
+ENV cachet_ver ${cachet_ver:-2.3.18}
 ENV archive_url ${archive_url:-https://github.com/cachethq/Cachet/archive/${cachet_ver}.tar.gz}
 
 ENV COMPOSER_VERSION 1.9.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     build:
       context: .
       args:
-        - cachet_ver=2.4
+        - cachet_ver=v2.3.18
     ports:
       - 80:8000
     links:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -210,7 +210,7 @@ initialize_system() {
 
 init_db() {
   echo "Initializing Cachet database ..."
-  php artisan cachet:install --no-interaction
+  php artisan app:install --no-interaction
   check_configured
 }
 


### PR DESCRIPTION
This change also uses the latest official release of Cachet by default and fixes a php issue with later versions of the alpine image.

This is reported as problems #379 and is related to https://github.com/CachetHQ/Cachet/issues/4186